### PR TITLE
Add 5dim core compatibility

### DIFF
--- a/src/data.lua
+++ b/src/data.lua
@@ -4,3 +4,24 @@ require("prototypes.item");
 require("prototypes.entity");
 require("prototypes.recipe");
 require("prototypes.technology");
+
+if mods["5dim_core"] then
+    local hpPipe = "high-pressure-pipe"
+    local hpPipeToGround = "high-pressure-pipe-to-ground"
+    local hpPump = "high-pressure-pump"
+    -- items
+    data.raw.item[hpPipe].subgroup = "transport-pipe"
+    data.raw.item[hpPipe].order = "ab"
+    data.raw.item[hpPipeToGround].subgroup = "transport-pipe-ground"
+    data.raw.item[hpPipeToGround].order = "ab"
+    data.raw.item[hpPump].subgroup = "liquid-small-pump"
+    data.raw.item[hpPump].order = "ab"
+
+    -- recipes
+    data.raw.recipe[hpPipe].subgroup = "transport-pipe"
+    data.raw.recipe[hpPipe].order = "ab"
+    data.raw.recipe[hpPipeToGround].subgroup = "transport-pipe-ground"
+    data.raw.recipe[hpPipeToGround].order = "ab"
+    data.raw.recipe[hpPump].subgroup = "liquid-small-pump"
+    data.raw.recipe[hpPump].order = "ab"
+end

--- a/src/info.json
+++ b/src/info.json
@@ -1,10 +1,16 @@
 {
 	"name": "high-pressure-pipes",
-    "version": "1.0.6",
-    "factorio_version": "1.1",
-    "title": "High-Pressure Pipes",
-    "author": "kendfrey",
-    "homepage": "https://github.com/kendfrey/high-pressure-pipes",
-    "dependencies": ["base >= 0.18", "? boblogistics >= 0.18.0", "? bobplates >= 0.18.0", "? bobtech >= 0.18.0"],
-    "description": "High-pressure pipes for faster throughput."
+	"version": "1.0.6",
+	"factorio_version": "1.1",
+	"title": "High-Pressure Pipes",
+	"author": "kendfrey",
+	"homepage": "https://github.com/kendfrey/high-pressure-pipes",
+	"dependencies": [
+		"base >= 0.18",
+		"? boblogistics >= 0.18.0",
+		"? bobplates >= 0.18.0",
+		"? bobtech >= 0.18.0",
+		"? 5dim_core >= 1.1.15"
+	],
+	"description": "High-pressure pipes for faster throughput."
 }


### PR DESCRIPTION
### Why?
When 5dim's core mod is enabled, it alters the vanilla pipes to be in a different group and subgroup. This makes high-pressure pipes unable to be an upgrade option for the vanilla pipes. Also, it means the high-pressure pipes are not in the same group in the GUI as the vanilla pipes.

### What was changed
This rectifies both of the above issues by changing the high-pressure pipes subgroup and ordering to better align with 5dim's way of doing things if 5dim's core mod is enabled.

### 5Dim? Core mod? What's that?
5Dim has made quite a few [mods](https://mods.factorio.com/user/mcguten) which add new tiers of items and what-not. I believe they all list his core mod as a dependency, and his core mod is what changes the groups that items belong to, and what-not, which is why we check exclusively for the core mod.